### PR TITLE
fix(#6): 修復核心共享模組 mypy 錯誤

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.8.0",
     "pre-commit>=3.6.0",
+    "types-PyYAML>=6.0.0",
+    "types-beautifulsoup4>=4.12.0",
 ]
 
 test = [

--- a/src/glyphs_info_mcp/server.py
+++ b/src/glyphs_info_mcp/server.py
@@ -10,7 +10,9 @@ import asyncio
 import logging
 import yaml
 from pathlib import Path
-from typing import Dict, Any, List
+from typing import Any
+
+from glyphs_info_mcp.shared.core.base_module import BaseMCPModule
 
 from glyphs_info_mcp.config import MODULES_CONFIG, MODULES_DIR
 
@@ -30,7 +32,7 @@ except ImportError as e:
     sys.exit(1)
 
 # Dynamic module loading
-def load_module_configs():
+def load_module_configs() -> list[tuple[Path, str]]:
     """Load module configuration from modules_config.yaml
 
     Returns:
@@ -64,7 +66,7 @@ def load_module_configs():
             (MODULES_DIR / "glyphs_api", "api")
         ]
 
-def import_module(module_path: Path, module_name: str):
+def import_module(module_path: Path, module_name: str) -> BaseMCPModule | None:
     """Dynamically import a module
 
     Supports two module structures:
@@ -78,12 +80,11 @@ def import_module(module_path: Path, module_name: str):
     Returns:
         Module instance or None
     """
+    paths_to_add: list[str] = []
     try:
         # Add module path to sys.path
         src_path = str(module_path / "src")
         module_root = str(module_path)
-
-        paths_to_add = []
         if (module_path / "src").exists():
             paths_to_add.append(src_path)
         paths_to_add.append(module_root)
@@ -93,7 +94,7 @@ def import_module(module_path: Path, module_name: str):
                 sys.path.insert(0, path)
 
         # Dynamically import module
-        module_instance = None
+        module_instance: BaseMCPModule | None = None
 
         # Use absolute imports to load modules from package
         if module_name == "vocabulary":
@@ -155,10 +156,10 @@ def import_module(module_path: Path, module_name: str):
 mcp = FastMCP("Glyphs MCP - Modular Architecture")
 
 # Global variables for modules
-_modules = {}
+_modules: dict[str, BaseMCPModule] = {}
 
 
-def main():
+def main() -> None:
     """Initialize and start the unified MCP server"""
     try:
         # Load module configurations from YAML

--- a/src/glyphs_info_mcp/shared/core/base_module.py
+++ b/src/glyphs_info_mcp/shared/core/base_module.py
@@ -3,12 +3,13 @@
 Shared Base Module Class - Unified foundation for all MCP modules
 """
 
-# mypy: ignore-errors
-
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from glyphs_info_mcp.shared.core.search_engine import SearchEngine
 
 logger = logging.getLogger(__name__)
 
@@ -22,12 +23,12 @@ class BaseMCPModule(ABC):
     3. Backward compatible tool interface
     """
 
-    def __init__(self, name: str, data_path: Path | None = None):
+    def __init__(self, name: str, data_path: Path | None = None) -> None:
         self.name = name
         self.data_path = data_path or Path(__file__).parent.parent / "data"
         self.tools: list[dict[str, Any]] = []
         self.is_initialized = False
-        self.search_engine = None  # Unified search engine (injected by server.py)
+        self.search_engine: "SearchEngine | None" = None
 
     @abstractmethod
     def initialize(self) -> bool:
@@ -39,7 +40,7 @@ class BaseMCPModule(ABC):
         """Get tools provided by module"""
         pass
 
-    def set_search_engine(self, search_engine):
+    def set_search_engine(self, search_engine: "SearchEngine") -> None:
         """Set unified search engine (called by server.py)
 
         Args:
@@ -49,7 +50,7 @@ class BaseMCPModule(ABC):
         logger.debug(f"Unified search engine injected into {self.name} module")
 
     def core_search(
-        self, query: str, max_results: int = 5, **kwargs
+        self, query: str, max_results: int = 5, **kwargs: Any
     ) -> list[dict[str, Any]]:
         """Core search functionality - Standardized search interface
 
@@ -89,5 +90,5 @@ class BaseMCPModule(ABC):
         """Get data file path"""
         return self.data_path / filename
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.__class__.__name__}(name={self.name})"

--- a/uv.lock
+++ b/uv.lock
@@ -337,6 +337,8 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-beautifulsoup4" },
+    { name = "types-pyyaml" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -381,6 +383,8 @@ requires-dist = [
     { name = "rich", specifier = ">=13.9.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "typer", specifier = ">=0.15.0" },
+    { name = "types-beautifulsoup4", marker = "extra == 'dev'", specifier = ">=4.12.0" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "typing-extensions", specifier = ">=4.12.0" },
 ]
 provides-extras = ["dev", "test", "docs"]
@@ -1519,6 +1523,48 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625, upload-time = "2025-05-26T14:30:31.824Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317, upload-time = "2025-05-26T14:30:30.523Z" },
+]
+
+[[package]]
+name = "types-beautifulsoup4"
+version = "4.12.0.20250516"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-html5lib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/d1/32b410f6d65eda94d3dfb0b3d0ca151f12cb1dc4cef731dcf7cbfd8716ff/types_beautifulsoup4-4.12.0.20250516.tar.gz", hash = "sha256:aa19dd73b33b70d6296adf92da8ab8a0c945c507e6fb7d5db553415cc77b417e", size = 16628, upload-time = "2025-05-16T03:09:09.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/79/d84de200a80085b32f12c5820d4fd0addcbe7ba6dce8c1c9d8605e833c8e/types_beautifulsoup4-4.12.0.20250516-py3-none-any.whl", hash = "sha256:5923399d4a1ba9cc8f0096fe334cc732e130269541d66261bb42ab039c0376ee", size = 16879, upload-time = "2025-05-16T03:09:09.051Z" },
+]
+
+[[package]]
+name = "types-html5lib"
+version = "1.1.11.20251117"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/f3/d9a1bbba7b42b5558a3f9fe017d967f5338cf8108d35991d9b15fdea3e0d/types_html5lib-1.1.11.20251117.tar.gz", hash = "sha256:1a6a3ac5394aa12bf547fae5d5eff91dceec46b6d07c4367d9b39a37f42f201a", size = 18100, upload-time = "2025-11-17T03:08:00.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/ab/f5606db367c1f57f7400d3cb3bead6665ee2509621439af1b29c35ef6f9e/types_html5lib-1.1.11.20251117-py3-none-any.whl", hash = "sha256:2a3fc935de788a4d2659f4535002a421e05bea5e172b649d33232e99d4272d08", size = 24302, upload-time = "2025-11-17T03:07:59.996Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
+]
+
+[[package]]
+name = "types-webencodings"
+version = "0.5.0.20251108"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/d6/75e381959a2706644f02f7527d264de3216cf6ed333f98eff95954d78e07/types_webencodings-0.5.0.20251108.tar.gz", hash = "sha256:2378e2ceccced3d41bb5e21387586e7b5305e11519fc6b0659c629f23b2e5de4", size = 7470, upload-time = "2025-11-08T02:56:00.132Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/4e/8fcf33e193ce4af03c19d0e08483cf5f0838e883f800909c6bc61cb361be/types_webencodings-0.5.0.20251108-py3-none-any.whl", hash = "sha256:e21f81ff750795faffddaffd70a3d8bfff77d006f22c27e393eb7812586249d8", size = 8715, upload-time = "2025-11-08T02:55:59.456Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

修復 `src/glyphs_info_mcp/shared/` 和 `src/glyphs_info_mcp/server.py` 中的 mypy 錯誤。

### 修復內容
- 移除 `base_module.py` 的 `# mypy: ignore-errors`
- 添加 `BaseMCPModule` 類型註解（`__init__`, `set_search_engine`, `core_search`, `__str__`）
- 添加 `server.py` 函數返回類型（`load_module_configs`, `import_module`, `main`）
- 添加 `types-PyYAML` 和 `types-beautifulsoup4` 到 dev 依賴

### 驗證結果
```bash
mypy src/glyphs_info_mcp/shared src/glyphs_info_mcp/server.py --show-error-codes
# Success: no issues found in 35 source files

pytest tests/test_shared_core/ -v
# 39 passed
```

## Test plan
- [x] mypy 檢查通過（0 errors）
- [x] 單元測試通過（39 passed）

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)