### PR TITLE
ci(#9): enable mypy type check in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run tests
+        run: uv run pytest tests/ -v --tb=short
+
+      - name: Run type check
+        run: uv run mypy src/glyphs_info_mcp tests --show-error-codes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,9 +24,8 @@ jobs:
       - name: Run tests
         run: uv run pytest tests/ -v --tb=short
 
-      # TODO: 修復 type errors 後啟用
-      # - name: Run type check
-      #   run: uv run mypy src/glyphs_info_mcp --ignore-missing-imports --exclude 'data/'
+      - name: Run type check
+        run: uv run mypy src/glyphs_info_mcp tests --show-error-codes
 
   build:
     needs: test


### PR DESCRIPTION
## Summary
- Add `ci.yml` workflow for automated testing on push/PR to main
- Update `publish.yml` to include mypy check before release
- Both workflows now run: `pytest` + `mypy`

## Changes
- New `.github/workflows/ci.yml` - runs on push/PR to main
- Updated `.github/workflows/publish.yml` - runs on tag push (release)

## Test plan
- [x] Local `uv run mypy src/glyphs_info_mcp tests --show-error-codes` passes
- [x] Local `uv run pytest tests/ -v` - all tests pass
- [ ] CI workflow should trigger on this PR

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)