### PR TITLE
feat(#29): add module enable/disable via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,20 @@
 # Python API, Plugin API, Drawing Tools, Plugin Templates 等資料
 # 位於: modules/glyphs-api/src/resources/GlyphsSDK
 
+# ═══════════════════════════════════════════════════════════════════
+# 模組啟用/禁用配置
+# ═══════════════════════════════════════════════════════════════════
+# 可用模組：vocabulary, handbook, api, glyphs_plugins, glyphs_news,
+#          glyphs_sdk, light_table_api, mekkablue_scripts
+#
+# 白名單模式：只啟用指定的模組（未列出的模組將被禁用）
+# GLYPHS_ENABLED_MODULES=handbook,api
+#
+# 黑名單模式：禁用指定的模組（其他模組保持啟用）
+# GLYPHS_DISABLED_MODULES=glyphs_news,glyphs_plugins
+#
+# 注意：若同時設定白名單和黑名單，白名單優先（黑名單被忽略）
+
 # 效能調校
 # GLYPHS_MCP_MAX_SEARCH_RESULTS=100
 # GLYPHS_MCP_SEARCH_TIMEOUT=60

--- a/README.md
+++ b/README.md
@@ -356,6 +356,46 @@ Or use the `env` field in Claude Desktop configuration:
 }
 ```
 
+### Module Enable/Disable
+
+By default, all modules are enabled. To control specific modules, use environment variables:
+
+**Available modules**: `vocabulary`, `handbook`, `api`, `glyphs_plugins`, `glyphs_news`, `glyphs_sdk`, `light_table_api`, `mekkablue_scripts`
+
+**Whitelist mode** (enable only specified modules):
+
+```json
+{
+  "mcpServers": {
+    "glyphs-info": {
+      "command": "uvx",
+      "args": ["glyphs-info-mcp"],
+      "env": {
+        "GLYPHS_ENABLED_MODULES": "handbook,api"
+      }
+    }
+  }
+}
+```
+
+**Blacklist mode** (disable specified modules):
+
+```json
+{
+  "mcpServers": {
+    "glyphs-info": {
+      "command": "uvx",
+      "args": ["glyphs-info-mcp"],
+      "env": {
+        "GLYPHS_DISABLED_MODULES": "glyphs_news,glyphs_plugins"
+      }
+    }
+  }
+}
+```
+
+> If both whitelist and blacklist are set, whitelist takes precedence.
+
 ## 🔗 Resources
 
 - [Glyphs Official Website](https://glyphsapp.com/)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -356,6 +356,46 @@ python --version  # 需要 3.10+
 }
 ```
 
+### 模組啟用/禁用
+
+預設情況下所有模組都會啟用。若要控制特定模組，可使用環境變數：
+
+**可用模組**：`vocabulary`、`handbook`、`api`、`glyphs_plugins`、`glyphs_news`、`glyphs_sdk`、`light_table_api`、`mekkablue_scripts`
+
+**白名單模式**（只啟用指定模組）：
+
+```json
+{
+  "mcpServers": {
+    "glyphs-info": {
+      "command": "uvx",
+      "args": ["glyphs-info-mcp"],
+      "env": {
+        "GLYPHS_ENABLED_MODULES": "handbook,api"
+      }
+    }
+  }
+}
+```
+
+**黑名單模式**（排除指定模組）：
+
+```json
+{
+  "mcpServers": {
+    "glyphs-info": {
+      "command": "uvx",
+      "args": ["glyphs-info-mcp"],
+      "env": {
+        "GLYPHS_DISABLED_MODULES": "glyphs_news,glyphs_plugins"
+      }
+    }
+  }
+}
+```
+
+> 若同時設定白名單和黑名單，白名單優先。
+
 ## 🔗 相關資源
 
 - [Glyphs 官方網站](https://glyphsapp.com/)

--- a/tests/test_module_filter.py
+++ b/tests/test_module_filter.py
@@ -1,0 +1,205 @@
+"""測試模組啟用/禁用功能
+
+Issue #29: 讓使用者可以啟用或關閉部分模組
+"""
+
+import logging
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+class TestValidModuleNames:
+    """VALID_MODULE_NAMES 常數測試"""
+
+    def test_contains_all_eight_modules(self) -> None:
+        """包含所有 8 個模組"""
+        from glyphs_info_mcp.config import VALID_MODULE_NAMES
+
+        expected = {
+            "vocabulary",
+            "handbook",
+            "api",
+            "glyphs_plugins",
+            "glyphs_news",
+            "glyphs_sdk",
+            "light_table_api",
+            "mekkablue_scripts",
+        }
+        assert VALID_MODULE_NAMES == expected
+
+
+class TestParseModuleList:
+    """parse_module_list() 函式測試"""
+
+    def test_empty_string_returns_empty_set(self) -> None:
+        """空字串回傳空集合"""
+        from glyphs_info_mcp.config import parse_module_list
+
+        assert parse_module_list("") == set()
+
+    def test_whitespace_only_returns_empty_set(self) -> None:
+        """只有空白回傳空集合"""
+        from glyphs_info_mcp.config import parse_module_list
+
+        assert parse_module_list("   ") == set()
+
+    def test_single_module(self) -> None:
+        """單一模組"""
+        from glyphs_info_mcp.config import parse_module_list
+
+        assert parse_module_list("handbook") == {"handbook"}
+
+    def test_multiple_modules(self) -> None:
+        """多個模組用逗號分隔"""
+        from glyphs_info_mcp.config import parse_module_list
+
+        result = parse_module_list("handbook,api,vocabulary")
+        assert result == {"handbook", "api", "vocabulary"}
+
+    def test_whitespace_around_names(self) -> None:
+        """名稱周圍有空白"""
+        from glyphs_info_mcp.config import parse_module_list
+
+        result = parse_module_list(" handbook , api ")
+        assert result == {"handbook", "api"}
+
+    def test_duplicate_names_deduplicated(self) -> None:
+        """重複名稱會去重"""
+        from glyphs_info_mcp.config import parse_module_list
+
+        result = parse_module_list("handbook,handbook,api")
+        assert result == {"handbook", "api"}
+
+    def test_invalid_name_ignored_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """無效名稱會被忽略並記錄警告"""
+        from glyphs_info_mcp.config import parse_module_list
+
+        result = parse_module_list("handbook,invalid_module,api")
+        assert result == {"handbook", "api"}
+        assert "invalid_module" in caplog.text
+        assert "Unknown module" in caplog.text
+
+    def test_empty_segments_ignored(self) -> None:
+        """空白段落被忽略"""
+        from glyphs_info_mcp.config import parse_module_list
+
+        result = parse_module_list("handbook,,api,")
+        assert result == {"handbook", "api"}
+
+
+class TestIsModuleEnabled:
+    """is_module_enabled() 函式測試"""
+
+    def test_no_env_vars_all_enabled(self) -> None:
+        """未設定任何環境變數時，所有模組皆啟用"""
+        from glyphs_info_mcp.config import (
+            DISABLED_MODULES_ENV,
+            ENABLED_MODULES_ENV,
+            is_module_enabled,
+        )
+
+        with patch.dict(
+            os.environ,
+            {ENABLED_MODULES_ENV: "", DISABLED_MODULES_ENV: ""},
+            clear=False,
+        ):
+            # 確保環境變數被清空
+            os.environ.pop(ENABLED_MODULES_ENV, None)
+            os.environ.pop(DISABLED_MODULES_ENV, None)
+
+            assert is_module_enabled("handbook") is True
+            assert is_module_enabled("api") is True
+            assert is_module_enabled("glyphs_news") is True
+
+    def test_whitelist_only_enables_listed_modules(self) -> None:
+        """白名單模式：只啟用列出的模組"""
+        from glyphs_info_mcp.config import ENABLED_MODULES_ENV, is_module_enabled
+
+        with patch.dict(os.environ, {ENABLED_MODULES_ENV: "handbook,api"}):
+            assert is_module_enabled("handbook") is True
+            assert is_module_enabled("api") is True
+            assert is_module_enabled("glyphs_news") is False
+            assert is_module_enabled("vocabulary") is False
+
+    def test_blacklist_disables_listed_modules(self) -> None:
+        """黑名單模式：排除列出的模組"""
+        from glyphs_info_mcp.config import DISABLED_MODULES_ENV, is_module_enabled
+
+        with patch.dict(os.environ, {DISABLED_MODULES_ENV: "glyphs_news,glyphs_plugins"}):
+            assert is_module_enabled("handbook") is True
+            assert is_module_enabled("api") is True
+            assert is_module_enabled("glyphs_news") is False
+            assert is_module_enabled("glyphs_plugins") is False
+
+    def test_whitelist_takes_precedence_over_blacklist(self) -> None:
+        """白名單優先於黑名單"""
+        from glyphs_info_mcp.config import (
+            DISABLED_MODULES_ENV,
+            ENABLED_MODULES_ENV,
+            is_module_enabled,
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                ENABLED_MODULES_ENV: "handbook,api",
+                DISABLED_MODULES_ENV: "api,glyphs_news",
+            },
+        ):
+            # 白名單優先，api 應該啟用
+            assert is_module_enabled("handbook") is True
+            assert is_module_enabled("api") is True
+            # 不在白名單中的模組被禁用
+            assert is_module_enabled("glyphs_news") is False
+            assert is_module_enabled("vocabulary") is False
+
+    def test_empty_whitelist_enables_all(self) -> None:
+        """空白名單等同於未設定，全部啟用"""
+        from glyphs_info_mcp.config import ENABLED_MODULES_ENV, is_module_enabled
+
+        with patch.dict(os.environ, {ENABLED_MODULES_ENV: ""}):
+            assert is_module_enabled("handbook") is True
+            assert is_module_enabled("glyphs_news") is True
+
+    def test_empty_blacklist_enables_all(self) -> None:
+        """空黑名單等同於未設定，全部啟用"""
+        from glyphs_info_mcp.config import DISABLED_MODULES_ENV, is_module_enabled
+
+        with patch.dict(os.environ, {DISABLED_MODULES_ENV: ""}):
+            assert is_module_enabled("handbook") is True
+            assert is_module_enabled("glyphs_news") is True
+
+    def test_invalid_module_name_returns_false(self) -> None:
+        """無效模組名稱回傳 False"""
+        from glyphs_info_mcp.config import is_module_enabled
+
+        assert is_module_enabled("nonexistent_module") is False
+
+    def test_logs_info_when_both_set(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """同時設定白名單和黑名單時記錄 INFO 日誌（首次呼叫時）"""
+        import glyphs_info_mcp.config as config_module
+        from glyphs_info_mcp.config import (
+            DISABLED_MODULES_ENV,
+            ENABLED_MODULES_ENV,
+            is_module_enabled,
+        )
+
+        # 重置全域狀態以確保日誌會被記錄
+        config_module._whitelist_precedence_logged = False
+
+        with patch.dict(
+            os.environ,
+            {
+                ENABLED_MODULES_ENV: "handbook",
+                DISABLED_MODULES_ENV: "api",
+            },
+        ):
+            with caplog.at_level(logging.INFO):
+                is_module_enabled("handbook")
+                assert "whitelist" in caplog.text.lower() or "enabled" in caplog.text.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "glyphs-info-mcp"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },


### PR DESCRIPTION
## Summary

- Add whitelist/blacklist support for controlling which modules are loaded via environment variables
- `GLYPHS_ENABLED_MODULES`: whitelist mode (only enable specified modules)
- `GLYPHS_DISABLED_MODULES`: blacklist mode (disable specified modules)
- Default behavior unchanged: all modules enabled when neither variable is set

## Test plan

- [x] Run `pytest tests/test_module_filter.py` - all 17 tests pass
- [x] Run full test suite - 686 tests pass
- [ ] Manual verification with `GLYPHS_ENABLED_MODULES=handbook,api` to confirm only 2 modules load
- [ ] Manual verification with `GLYPHS_DISABLED_MODULES=glyphs_news` to confirm module is skipped

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)