### PR TITLE
feat(#38): Add Python Samples tool layer and unified entry support

### DIFF
--- a/src/glyphs_info_mcp/modules/glyphs_sdk/glyphs_sdk_module.py
+++ b/src/glyphs_info_mcp/modules/glyphs_sdk/glyphs_sdk_module.py
@@ -686,6 +686,133 @@ class GlyphsSDKModule(BaseMCPModule):
             return f"❌ Error getting Xcode sample: {e}"
 
     # ============================================================================
+    # Python Samples Tools (Issue #38)
+    # ============================================================================
+
+    def _list_python_samples_tool(self) -> str:
+        """
+        [SDK] List all Python sample plugins
+
+        Display available Python sample plugins demonstrating various plugin types
+        and implementation patterns. Samples include complete working code.
+
+        Sample types:
+        - Script samples (standalone Python scripts)
+        - Plugin samples (.glyphsPlugin bundles)
+        - Palette samples (.glyphsPalette bundles)
+        - Tool samples (.glyphsTool bundles)
+
+        Related resources:
+        - Use sdk(action="get_python_sample") to view specific sample's complete code
+        - Use api(action="search_python") to view API definitions used
+
+        Returns:
+            Sample list with name, type, and file information
+        """
+        if not self.native_accessor:
+            return "❌ Native Accessor not initialized"
+
+        try:
+            samples = self.native_accessor.list_python_samples()
+
+            if not samples:
+                return "No Python sample plugins found"
+
+            result = "## 🐍 Python Sample Plugin List\n\n"
+            result += f"Found {len(samples)} sample plugins\n\n"
+
+            for sample in samples:
+                result += f"### {sample['name']}\n"
+                result += f"- **Type**: {sample['type']}\n"
+                result += f"- **Bundle**: {'✅ Yes' if sample['has_bundle'] else '❌ No (standalone script)'}\n"
+                result += f"- **Source files**: {sample['source_file_count']}\n"
+
+                if sample.get("readme"):
+                    # Only show first 200 characters of README
+                    readme_preview = sample["readme"][:200].strip()
+                    result += f"- **Description**: {readme_preview}{'...' if len(sample['readme']) > 200 else ''}\n"
+
+                result += f"- **Path**: `{sample['path']}`\n\n"
+
+            result += "\n💡 **Usage tips**:\n"
+            result += "- Use `sdk(action=\"get_python_sample\", sample_name=\"...\")` to view specific sample's complete code\n"
+            result += "- Bundle samples can be installed directly to ~/Library/Application Support/Glyphs 3/Plugins/\n"
+            result += "- Standalone scripts can be run from Script menu or used as reference\n"
+
+            return result
+
+        except Exception as e:
+            return f"❌ Error listing Python samples: {e}"
+
+    def _get_python_sample_tool(self, sample_name: str) -> str:
+        """
+        [SDK] Get complete information of a specific Python sample
+
+        Retrieves complete content of Python sample plugin, including:
+        - README documentation
+        - Complete Python source code files
+        - Plugin structure information
+
+        Args:
+            sample_name: Sample name (e.g., "Plugin With Window" or "Callback for context menu")
+
+        Returns:
+            Sample documentation, file structure, and complete source code
+        """
+        if not self.native_accessor:
+            return "❌ Native Accessor not initialized"
+
+        if not sample_name:
+            return "Please provide a sample name"
+
+        try:
+            sample = self.native_accessor.get_python_sample(sample_name)
+
+            if not sample:
+                available = self.native_accessor.list_python_samples()
+                names = [s["name"] for s in available]
+                return f"❌ Sample not found: {sample_name}\n\nAvailable samples:\n" + "\n".join(
+                    f"- {n}" for n in names
+                )
+
+            result = f"## 🐍 {sample['name']}\n\n"
+            result += f"**Type**: {sample['type']}\n"
+            result += f"**Bundle**: {'✅ Yes' if sample['has_bundle'] else '❌ No (standalone script)'}\n"
+            result += f"**Source files**: {sample['source_file_count']}\n\n"
+
+            # Show README
+            if sample.get("readme"):
+                result += "### 📖 README\n\n"
+                result += f"{sample['readme']}\n\n"
+
+            # List source files
+            result += f"### 📁 Source Files ({sample['source_file_count']})\n\n"
+            for file_info in sample["source_files"]:
+                result += f"- `{file_info['path']}`\n"
+
+            # Show source code content
+            result += "\n### 💻 Source Code\n\n"
+            source_code = sample.get("source_code", {})
+
+            for file_path, content in source_code.items():
+                result += f"#### `{file_path}`\n\n"
+                result += f"```python\n{content}\n```\n\n"
+
+            # Show load errors if any
+            if sample.get("partial_load"):
+                load_errors = sample.get("load_errors", [])
+                result += "### ⚠️ Load Warnings\n\n"
+                result += "Some files could not be loaded:\n\n"
+                for error in load_errors:
+                    result += f"- `{error['file']}`: {error['error']}\n"
+                result += "\n"
+
+            return result
+
+        except Exception as e:
+            return f"❌ Error getting Python sample: {e}"
+
+    # ============================================================================
     # MCP Resources Implementation (Issue #33)
     # ============================================================================
 

--- a/src/glyphs_info_mcp/unified_tools.py
+++ b/src/glyphs_info_mcp/unified_tools.py
@@ -502,6 +502,8 @@ class UnifiedToolsRouter:
         - get_sample: Get Xcode sample (sample_name)
         - list_python_templates: List Python plugin templates (template_type)
         - get_python_template: Get Python template details (template_id)
+        - list_python_samples: List Python sample plugins (Issue #38)
+        - get_python_sample: Get Python sample details (sample_name) (Issue #38)
 
         Args:
             action: Operation to perform
@@ -549,8 +551,13 @@ class UnifiedToolsRouter:
                 return module._list_python_templates_tool(template_type=template_type if template_type else None)
             elif action == "get_python_template":
                 return module._get_python_template_tool(template_id=template_id)
+            # Python Samples (Issue #38)
+            elif action == "list_python_samples":
+                return module._list_python_samples_tool()
+            elif action == "get_python_sample":
+                return module._get_python_sample_tool(sample_name=sample_name)
             else:
-                return f"## Invalid Action\n\nUnknown action: `{action}`\n\nAvailable actions: search, get, list_xcode_templates, get_xcode_template, list_samples, get_sample, list_python_templates, get_python_template"
+                return f"## Invalid Action\n\nUnknown action: `{action}`\n\nAvailable actions: search, get, list_xcode_templates, get_xcode_template, list_samples, get_sample, list_python_templates, get_python_template, list_python_samples, get_python_sample"
 
         except Exception as e:
             logger.error(f"SDK action '{action}' failed: {e}")

--- a/tests/test_glyphs_sdk/test_python_samples_tools.py
+++ b/tests/test_glyphs_sdk/test_python_samples_tools.py
@@ -1,0 +1,170 @@
+"""Tests for Python Samples tool layer (Issue #38)
+
+Tests for _list_python_samples_tool() and _get_python_sample_tool()
+following the Xcode Samples pattern.
+"""
+
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from glyphs_info_mcp.modules.glyphs_sdk.glyphs_sdk_module import GlyphsSDKModule
+from glyphs_info_mcp.shared.core.sdk_native_accessor import SDKNativeAccessor
+
+
+@pytest.fixture
+def sdk_path() -> Path:
+    """Get GlyphsSDK path"""
+    project_root = Path(__file__).parent.parent.parent
+    return (
+        project_root / "src" / "glyphs_info_mcp" / "data" / "official" / "GlyphsSDK"
+    )
+
+
+@pytest.fixture
+def native_accessor(sdk_path: Path) -> SDKNativeAccessor:
+    """Create SDKNativeAccessor instance"""
+    return SDKNativeAccessor(sdk_path)
+
+
+@pytest.fixture
+def sdk_module() -> GlyphsSDKModule:
+    """Create GlyphsSDKModule instance and initialize it"""
+    module = GlyphsSDKModule()
+    module.initialize()
+    return module
+
+
+class TestListPythonSamplesTool:
+    """Tests for _list_python_samples_tool()"""
+
+    def test_returns_markdown_format(self, sdk_module: GlyphsSDKModule) -> None:
+        """Test that result is formatted as Markdown"""
+        result = sdk_module._list_python_samples_tool()
+
+        assert result.startswith("## ")
+        assert "Python Sample" in result
+
+    def test_shows_sample_count(self, sdk_module: GlyphsSDKModule) -> None:
+        """Test that result shows sample count"""
+        result = sdk_module._list_python_samples_tool()
+
+        # Should mention the count of samples found
+        assert "6" in result or "Found" in result
+
+    def test_shows_sample_info(self, sdk_module: GlyphsSDKModule) -> None:
+        """Test that result shows sample information"""
+        result = sdk_module._list_python_samples_tool()
+
+        # Should show sample names
+        assert "Callback for context menu" in result or "context menu" in result.lower()
+
+        # Should show type information
+        assert "Type" in result or "type" in result
+
+        # Should show source file count
+        assert "Source" in result or "files" in result.lower()
+
+    def test_shows_usage_tips(self, sdk_module: GlyphsSDKModule) -> None:
+        """Test that result includes usage tips"""
+        result = sdk_module._list_python_samples_tool()
+
+        assert "tip" in result.lower() or "usage" in result.lower()
+
+    def test_handles_no_native_accessor(self) -> None:
+        """Test error handling when native accessor not initialized"""
+        module = GlyphsSDKModule.__new__(GlyphsSDKModule)
+        module.native_accessor = None
+
+        result = module._list_python_samples_tool()
+
+        assert "not initialized" in result.lower() or "error" in result.lower()
+
+
+class TestGetPythonSampleTool:
+    """Tests for _get_python_sample_tool()"""
+
+    def test_returns_sample_content(self, sdk_module: GlyphsSDKModule) -> None:
+        """Test that result contains sample content"""
+        result = sdk_module._get_python_sample_tool("Callback for context menu")
+
+        assert "Callback for context menu" in result
+        assert "Source" in result or "code" in result.lower()
+
+    def test_shows_sample_type(self, sdk_module: GlyphsSDKModule) -> None:
+        """Test that result shows sample type"""
+        result = sdk_module._get_python_sample_tool("Callback for context menu")
+
+        assert "Type" in result or "type" in result
+
+    def test_shows_source_code(self, sdk_module: GlyphsSDKModule) -> None:
+        """Test that result includes source code blocks"""
+        result = sdk_module._get_python_sample_tool("Callback for context menu")
+
+        # Should contain Python code blocks
+        assert "```python" in result or "```" in result
+
+    def test_shows_file_structure(self, sdk_module: GlyphsSDKModule) -> None:
+        """Test that result shows file structure"""
+        result = sdk_module._get_python_sample_tool("Callback for context menu")
+
+        assert "File" in result and ".py" in result
+
+    def test_not_found_lists_available(self, sdk_module: GlyphsSDKModule) -> None:
+        """Test that not found returns available samples list"""
+        result = sdk_module._get_python_sample_tool("NonExistentSample")
+
+        assert "not found" in result.lower() or "available" in result.lower()
+        # Should list some available samples
+        assert "Callback" in result or "Plugin" in result
+
+    def test_empty_name_error(self, sdk_module: GlyphsSDKModule) -> None:
+        """Test error handling for empty sample name"""
+        result = sdk_module._get_python_sample_tool("")
+
+        assert "provide" in result.lower() or "name" in result.lower()
+
+    def test_handles_no_native_accessor(self) -> None:
+        """Test error handling when native accessor not initialized"""
+        module = GlyphsSDKModule.__new__(GlyphsSDKModule)
+        module.native_accessor = None
+
+        result = module._get_python_sample_tool("test")
+
+        assert "not initialized" in result.lower() or "error" in result.lower()
+
+
+class TestUnifiedToolsIntegration:
+    """Tests for unified tools integration (Issue #38)"""
+
+    def test_sdk_list_python_samples_action(self) -> None:
+        """Test sdk router dispatches list_python_samples action correctly"""
+        from glyphs_info_mcp.unified_tools import UnifiedToolsRouter
+
+        mock_module = MagicMock()
+        mock_module._list_python_samples_tool.return_value = "sample list"
+
+        router = UnifiedToolsRouter()
+        router.set_module("glyphs_sdk", mock_module)
+
+        result = router.sdk(action="list_python_samples")
+
+        mock_module._list_python_samples_tool.assert_called_once()
+        assert result == "sample list"
+
+    def test_sdk_get_python_sample_action(self) -> None:
+        """Test sdk router dispatches get_python_sample action correctly"""
+        from glyphs_info_mcp.unified_tools import UnifiedToolsRouter
+
+        mock_module = MagicMock()
+        mock_module._get_python_sample_tool.return_value = "sample details"
+
+        router = UnifiedToolsRouter()
+        router.set_module("glyphs_sdk", mock_module)
+
+        result = router.sdk(action="get_python_sample", sample_name="Plugin With Window")
+
+        mock_module._get_python_sample_tool.assert_called_once_with(
+            sample_name="Plugin With Window"
+        )
+        assert result == "sample details"


### PR DESCRIPTION
## Summary

- Add tool layer methods (`_list_python_samples_tool()`, `_get_python_sample_tool()`) to GlyphsSDKModule
- Add `list_python_samples` and `get_python_sample` actions to unified `sdk()` entry point
- Add comprehensive test suite with 14 test cases
- Achieve feature parity with Xcode Samples

## Test plan

- [x] All 14 new tests pass
- [x] Full test suite (780 tests) passes
- [x] Mypy type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)